### PR TITLE
feat: 最長増加部分列を追加

### DIFF
--- a/others/longest_increasing_subsequence.hpp
+++ b/others/longest_increasing_subsequence.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include "template.hpp"
+
+vector<int> longest_increasing_subsequence(const vector<int>& v,
+                                           bool strictly = true) {
+  if (v.empty()) return {};
+  vector<int> dp, idx, prev(v.size());
+  rep(i, v.size()) {
+    auto it = strictly ? lower_bound(dp.begin(), dp.end(), v[i])
+                       : upper_bound(dp.begin(), dp.end(), v[i]);
+    int pos = it - dp.begin();
+    if (it == dp.end()) {
+      dp.emplace_back(v[i]);
+      idx.emplace_back(i);
+    } else {
+      *it = v[i];
+      idx[pos] = i;
+    }
+    prev[i] = (0 < pos) ? idx[pos - 1] : -1;
+  }
+  vector<int> ret;
+  for (int i = idx.back(); i != -1; i = prev[i]) ret.emplace_back(i);
+  ranges::reverse(ret);
+  return ret;
+}

--- a/others/longest_increasing_subsequence.test.cpp
+++ b/others/longest_increasing_subsequence.test.cpp
@@ -1,0 +1,14 @@
+#define PROBLEM "https://judge.yosupo.jp/problem/longest_increasing_subsequence"
+#include "others/longest_increasing_subsequence.hpp"
+
+#include "template.hpp"
+signed main() {
+  cin.tie(nullptr)->sync_with_stdio(false);
+  int N;
+  cin >> N;
+  vector<int> A(N);
+  rep(i, N) cin >> A[i];
+  auto ans = longest_increasing_subsequence(A);
+  cout << ans.size() << endl;
+  rep(i, ans.size()) cout << ans[i] << " \n"[i + 1 == (int)ans.size()];
+}


### PR DESCRIPTION
### 概要

与えられた数列の最長増加部分列（Longest Increasing Subsequence, LIS）を $O(N \log N)$ で一つ求める関数 `longest_increasing_subsequence` を実装しました。

### 主な機能

- LISそのものではなく、元の数列におけるインデックスの列を返します。
- 第二引数 `strictly` （デフォルトは `true` ）により、狭義の増加部分列と、広義の増加部分列との両方に対応できます。
